### PR TITLE
Fix crash due to removed constructor.

### DIFF
--- a/imageloader/src/extension.cpp
+++ b/imageloader/src/extension.cpp
@@ -135,7 +135,7 @@ static void push_image_resource(lua_State *L, int width, int height, int channel
 	lua_setfield(L, -2, "header");
 
 	if (buffer != 0) {
-		dmScript::LuaHBuffer lua_buffer = {buffer, true};
+		dmScript::LuaHBuffer lua_buffer(buffer, dmScript::OWNER_LUA);
 		dmScript::PushBuffer(L, lua_buffer);
 		lua_setfield(L, -2, "buffer");
 	}


### PR DESCRIPTION
The old constructor was removed. This uses the replacement. A deprecation was added in 1.2.191 (if I am not mistaken) and removed later. [This forum post](https://forum.defold.com/t/ne-updated-dmscript-luahbuffer-constructor/69931) details it.

I have not tested this PR because I don't have a env set up, but it should be entirely working.

This pull request would close #1 and #2 .